### PR TITLE
Energy Curve: Switching softly between contracts

### DIFF
--- a/src/pages/TimeCurves.js
+++ b/src/pages/TimeCurves.js
@@ -31,7 +31,7 @@ function TimeCurvesPage(props) {
     token,
     contract,
     cups,
-    currentMonth = dayjs().format('YYYYMM'),
+    now = dayjs(),
   } = props
 
   const [type, setType] = useState('LINE_CHART_TYPE')
@@ -43,34 +43,36 @@ function TimeCurvesPage(props) {
 
   useEffect(function () {
     const requestData = async () => {
+      // TODO: use Promise.all() to parallelize
+      // TODO: use [3,2,1,0].map() to reduce duplication
       const response = await getTimeCurves({
         token,
         cups,
-        currentMonth,
+        currentMonth: now.subtract(0, 'year').format('YYYYMM'),
       })
 
       const response2 = await getTimeCurves({
         token,
         cups,
-        currentMonth: dayjs().subtract(1, 'year').format('YYYYMM'),
+        currentMonth: now.subtract(1, 'year').format('YYYYMM'),
       })
 
       const response3 = await getTimeCurves({
         token,
         cups,
-        currentMonth: dayjs().subtract(2, 'year').format('YYYYMM'),
+        currentMonth: now.subtract(2, 'year').format('YYYYMM'),
       })
 
       const response4 = await getTimeCurves({
         token,
         cups,
-        currentMonth: dayjs().subtract(3, 'year').format('YYYYMM'),
+        currentMonth: now.subtract(3, 'year').format('YYYYMM'),
       })
 
       setTimeCurves([...response4, ...response3, ...response2, ...response])
     }
     requestData()
-  }, [])
+  }, [token, cups])
 
   const DownloadButton = (props) => {
     const { children } = props

--- a/src/pages/TimeCurves.js
+++ b/src/pages/TimeCurves.js
@@ -29,12 +29,12 @@ function TimeCurvesPage(props) {
 
   const {
     token,
-    contract,
-    cups,
     now = dayjs(),
   } = props
 
   const [type, setType] = useState('LINE_CHART_TYPE')
+  const [cups, setCups] = useState(props.cups)
+  const [contract, setContract] = useState(props.contract)
 
   useEffect(() => {
     language && i18n.changeLanguage(language)
@@ -56,6 +56,12 @@ function TimeCurvesPage(props) {
     }
     requestData()
   }, [token, cups])
+
+  window.switchcontract = (newContract, newCups) => {
+    setTimeCurves([])
+    setContract(newContract)
+    setCups(newCups)
+  }
 
   const DownloadButton = (props) => {
     const { children } = props

--- a/src/pages/TimeCurves.js
+++ b/src/pages/TimeCurves.js
@@ -43,33 +43,16 @@ function TimeCurvesPage(props) {
 
   useEffect(function () {
     const requestData = async () => {
-      // TODO: use Promise.all() to parallelize
-      // TODO: use [3,2,1,0].map() to reduce duplication
-      const response = await getTimeCurves({
-        token,
-        cups,
-        currentMonth: now.subtract(0, 'year').format('YYYYMM'),
-      })
-
-      const response2 = await getTimeCurves({
-        token,
-        cups,
-        currentMonth: now.subtract(1, 'year').format('YYYYMM'),
-      })
-
-      const response3 = await getTimeCurves({
-        token,
-        cups,
-        currentMonth: now.subtract(2, 'year').format('YYYYMM'),
-      })
-
-      const response4 = await getTimeCurves({
-        token,
-        cups,
-        currentMonth: now.subtract(3, 'year').format('YYYYMM'),
-      })
-
-      setTimeCurves([...response4, ...response3, ...response2, ...response])
+      const responses = await Promise.all(
+        [3,2,1,0].map((yearsago) => {
+          return getTimeCurves({
+            token,
+            cups,
+            currentMonth: now.subtract(yearsago, 'year').format('YYYYMM'),
+          })
+        })
+      )
+      setTimeCurves(responses.flat())
     }
     requestData()
   }, [token, cups])


### PR DESCRIPTION
This pull request does two things:
- Parallelizes and speedups the retrieval of curve data, also by reducing duplicated code
- Enables the dinamic change of contract, avoiding a page reload.

This should be companion of the related [backend PR](https://github.com/Som-Energia/oficinavirtual/pull/29) 

I specially would like review of two aspects, i suspect  i could drift from React way of doing things:

 - Because the dynamic change is triggered by a vanilla/jquery component outside react it is done by calling a callback. It is a temporary hack since at the end of the day the ideal solution would be to put the outside component inside the react one. Even though, being a temporary hack i could be missing some side effect in React of this hack.

- I turned some properties into state, being the state just the initial value. Then depend the useEffect of those states, which is changed from the callback. Also React-way TM review.

- The callback was put in `window`. Maybe there is a better place for it. Or a better name to avoid collisions.