### PR TITLE
Fix 30 td disabling for multiple contracts

### DIFF
--- a/src/pages/EnergyUse.js
+++ b/src/pages/EnergyUse.js
@@ -6,7 +6,7 @@ import dayjs from 'dayjs'
 import 'dayjs/locale/ca'
 import 'dayjs/locale/es'
 
-import TipicialDailyProfile from '../containers/TipicalDailyProfile'
+import TipicalDailyProfile from '../containers/TipicalDailyProfile'
 import TipicalWeeklyProfile from '../containers/TipicalWeeklyProfile'
 import LastMonthProfile from '../containers/LastMonthsProfile'
 import SeasonalProfile from '../containers/SeasonalProfile'
@@ -26,7 +26,7 @@ function EnergyUse(props) {
   const tabs = [
     {
       title: t('TIPICAL_DAILY_PROFILE'),
-      content: <TipicialDailyProfile {...props} />,
+      content: <TipicalDailyProfile {...props} />,
     },
     {
       title: t('TIPICAL_WEEKLY_PROFILE'),

--- a/src/pages/TimeCurves.js
+++ b/src/pages/TimeCurves.js
@@ -27,14 +27,11 @@ function TimeCurvesPage(props) {
   const { timeCurves, setTimeCurves, filteredTimeCurves } =
     useContext(TimeCurvesContext)
 
-  const {
-    token,
-    now = dayjs(),
-    tariff
-  } = props
+  const { token, now = dayjs() } = props
 
   const [type, setType] = useState('LINE_CHART_TYPE')
   const [cups, setCups] = useState(props.cups)
+  const [tariff, setTariff] = useState(props.tariff)
   const [contract, setContract] = useState(props.contract)
 
   useEffect(() => {
@@ -58,10 +55,11 @@ function TimeCurvesPage(props) {
     requestData()
   }, [token, cups])
 
-  window.switchcontract = (newContract, newCups) => {
+  window.switchcontract = (newContract, newCups, newTariff) => {
     setTimeCurves([])
     setContract(newContract)
     setCups(newCups)
+    setTariff(newTariff)
   }
 
   const DownloadButton = (props) => {

--- a/src/pages/TimeCurves.js
+++ b/src/pages/TimeCurves.js
@@ -39,21 +39,24 @@ function TimeCurvesPage(props) {
     language ? dayjs.locale(language) : dayjs.locale('es')
   }, [language, i18n])
 
-  useEffect(function () {
-    const requestData = async () => {
-      const responses = await Promise.all(
-        [3,2,1,0].map((yearsago) => {
-          return getTimeCurves({
-            token,
-            cups,
-            currentMonth: now.subtract(yearsago, 'year').format('YYYYMM'),
+  useEffect(
+    function () {
+      const requestData = async () => {
+        const responses = await Promise.all(
+          [3, 2, 1, 0].map((yearsago) => {
+            return getTimeCurves({
+              token,
+              cups,
+              currentMonth: now.subtract(yearsago, 'year').format('YYYYMM'),
+            })
           })
-        })
-      )
-      setTimeCurves(responses.flat())
-    }
-    requestData()
-  }, [token, cups])
+        )
+        setTimeCurves(responses.flat())
+      }
+      requestData()
+    },
+    [token, cups]
+  )
 
   window.switchcontract = (newContract, newCups, newTariff) => {
     setTimeCurves([])
@@ -118,25 +121,45 @@ function TimeCurvesPage(props) {
           {
             title: t('DAILY'),
             content: (
-              <TimeCurves period="DAILY" chartType={type} data={timeCurves} tariff={tariff} />
+              <TimeCurves
+                period="DAILY"
+                chartType={type}
+                data={timeCurves}
+                tariff={tariff}
+              />
             ),
           },
           {
             title: t('WEEKLY'),
             content: (
-              <TimeCurves period="WEEKLY" chartType={type} data={timeCurves} tariff={tariff} />
+              <TimeCurves
+                period="WEEKLY"
+                chartType={type}
+                data={timeCurves}
+                tariff={tariff}
+              />
             ),
           },
           {
             title: t('MONTHLY'),
             content: (
-              <TimeCurves period="MONTHLY" chartType={type} data={timeCurves} tariff={tariff} />
+              <TimeCurves
+                period="MONTHLY"
+                chartType={type}
+                data={timeCurves}
+                tariff={tariff}
+              />
             ),
           },
           {
             title: t('YEARLY'),
             content: (
-              <TimeCurves period="YEARLY" chartType={type} data={timeCurves} tariff={tariff} />
+              <TimeCurves
+                period="YEARLY"
+                chartType={type}
+                data={timeCurves}
+                tariff={tariff}
+              />
             ),
           },
         ]}


### PR DESCRIPTION
Recently some aspects of infoenergia curves and use pages were blocked for non-2.0 contracts since they are not available. The implementation of those restrictions was not working properly with users with multiple contracts because the tariff information was not propagated properly.

- For energy curves, where contract switch is resolved within the browser, the tariff was not updated and all the contracts used the first contract tariff.
- For energy use, where contract switch is resolved by reloading the page, on reload the tariff was set to the cups and never matched the 2.0 tariff.

This patch sets and propagates the tariff value properly in both cases.

This PR twins with backend's https://github.com/Som-Energia/oficinavirtual/pull/45
In response to this issue https://secure.helpscout.net/conversation/2115956207/14021240?folderId=3063450